### PR TITLE
Add `apply` function to Refinement<T, P>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,38 @@ where
     pub fn into_inner(self) -> T {
         self.0
     }
+
+    /// Apply a function `f` to the current underlying value
+    /// (consuming `self`). Then, creates a refined value
+    /// from the result of `f`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use refinement::{Predicate, Refinement};
+    ///
+    /// struct IsVolumeLevel;
+    ///
+    /// impl Predicate<u32> for IsVolumeLevel {
+    ///     fn test(x: &u32) -> bool {
+    ///         (0u32..64u32).contains(x)
+    ///     }
+    /// }
+    ///
+    /// type VolumeLevel = Refinement<u32, IsVolumeLevel>;
+    ///
+    /// let ok = VolumeLevel::new(5u32).unwrap().apply(|v| v + 10u32);
+    /// assert_eq!(15u32, ok.unwrap().into_inner());
+    ///
+    /// let err = VolumeLevel::new(60u32).unwrap().apply(|v| v + 10u32);
+    /// assert!(err.is_none());
+    /// ```
+    pub fn apply<F>(self, f: F) -> Option<Self>
+    where
+        F: FnOnce(T) -> T,
+    {
+        Self::new(f(self.into_inner()))
+    }
 }
 
 impl<T, P> std::fmt::Debug for Refinement<T, P>

--- a/tests/less_than_ten.rs
+++ b/tests/less_than_ten.rs
@@ -17,3 +17,16 @@ fn add() {
     let y = LessThanTen::new(5).unwrap();
     let _z = x + y;
 }
+
+#[test]
+fn add_cascading() {
+    let x = LessThanTen::new(5).unwrap();
+    let y = LessThanTen::new(2).unwrap();
+    let z = x.apply(|v| v + y.into_inner());
+    assert_eq!(7, z.unwrap().into_inner());
+
+    let x = LessThanTen::new(5).unwrap();
+    let y = LessThanTen::new(5).unwrap();
+    let z = x.apply(|v| v + y.into_inner());
+    assert!(z.is_none());
+}


### PR DESCRIPTION
Add an `apply` function that applies a function `f` to the underlying value of the Refinement type and then tries to refine the resulting value as well.

Basically, this implements what was suggested here: https://github.com/2bdkid/refinement/issues/6#issuecomment-1250140335...

I'm not entirely convinced about the naming of the function, though...

I thought calling it `map` as in the case of `Option<T>::map` but in that case, the function goes from `Option<T>` to `Option<U>` with `f` being `T -> U`.

This one goes from `Refinement<T, P>` to `Option<Refinement<T, P>>` with `f` being `T -> T`, so I thought that `apply` fits better...

Please, feel free to drop the pull request if you don't believe it's important or worth of your time (or if it needs to be improved a lot). Thanks.